### PR TITLE
Switching from esnext to babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var escompile = require('esnext').compile;
-var Transpiler = require('es6-module-transpiler').Compiler;
-
-var formats = {
-	'amd': 'toAMD',
-	'yui': 'toYUI',
-	'cjs': 'toCJS',
-	'globals': 'toGlobals'
-};
+var babel = require('babel');
 
 module.exports = function pluging(env, callback) {
 	function EsCompiler(path, content) {
@@ -31,18 +23,10 @@ module.exports = function pluging(env, callback) {
 	};
 	EsCompiler.prototype.getView = function() {
 		return function view(env, locals, contents, templates, callback) {
-			var config = env.config.esnext || {},
-			format = formats[config.format || 'globals'],
-			transpileConf = {
-				compatFix: true
-			};
-			env.utils.extend(transpileConf, config.transpilerOptions);
-
-			var intermed = escompile(this.content, config.compilerOptions),
-			localCompiler = new Transpiler(intermed.code,
-										   this.getModulename(config.anonymous),
-										   transpileConf);
-			callback(null, new Buffer(localCompiler[format]()));
+			var config = env.config.babel || {};
+			var es6 = babel.transform(this.content, config.compilerOptions);
+	
+			callback(null, new Buffer(es6));
 		};
 	};
 	EsCompiler.fromFile = function(path, callback) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wintersmith-esnext",
+  "name": "wintersmith-babel",
   "version": "1.0.2",
-  "description": "Wintersmith plugin for ES6 transpiling",
+  "description": "Wintersmith plugin for ES6 transpiling (using Babel)",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/Aintaer/wintersmith-esnext",
   "dependencies": {
-    "es6-module-transpiler": "^0.4.0",
-    "esnext": "^0.7.9"
+    "babel": "^4.4.0"
   }
 }


### PR DESCRIPTION
Babel (formerly 6to5): https://babeljs.io looks to be the standard for ES6 transpiling going forward. It can also handle different module formats, so it removes the need for es6-module-transpiler.
